### PR TITLE
Add `total_orders_count` attribute in `Customer`

### DIFF
--- a/src/resources/customers.ts
+++ b/src/resources/customers.ts
@@ -28,6 +28,7 @@ interface Customer extends Resource {
 	email: string
 	status: 'prospect' | 'acquired' | 'repeat'
 	has_password?: boolean | null
+	total_orders_count: number
 
 	customer_group?: CustomerGroup | null
 	customer_addresses?: CustomerAddress[] | null
@@ -40,7 +41,6 @@ interface Customer extends Resource {
 	attachments?: Attachment[] | null
 	events?: Event[] | null
 	tags?: Tag[] | null
-
 }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added the new attribute `total_orders_count` in `Customer` resource. It is of type `number` (`not nullable` / default `0`).

